### PR TITLE
docs: clarify requirement for DECO_DEPLOY_TOKEN in CI workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,39 @@ After creating your app (via npm create or GitHub template), you must:
 
 **Note**: The template comes with default values (`name = "deco-create"`, `scope = "kmute"`). You must run `npm run configure` to set your own values before development or deployment.
 
+## 🔐 GitHub Secret: `DECO_DEPLOY_TOKEN`
+
+To enable **preview deployments** with GitHub Actions, you must configure a deploy token.
+
+### 1️⃣ Generate a Deco Deploy Token
+
+Run:
+```bash
+deco token create
+```
+Or generate one from your Deco dashboard.
+
+
+### 2️⃣ Add the Token to GitHub Secrets
+Go to your repository → Settings → Secrets and variables → Actions
+
+Click New repository secret
+
+Enter the exact name:
+DECO_DEPLOY_TOKEN
+
+Paste your deploy token and Save
+
+Your GitHub workflow will automatically read the token using:
+
+```yaml
+${{ secrets.DECO_DEPLOY_TOKEN }}
+```
+### ⚠️ Without this secret, preview deployments will fail.
+
+
+
+
 ## 📁 Project Structure
 
 ```


### PR DESCRIPTION
This PR adds missing documentation for the required DECO_DEPLOY_TOKEN secret used in .github/workflows/deploy-preview.yml.

The preview deployment workflow depends on:

${{ secrets.DECO_DEPLOY_TOKEN }}


Without a configured token, the action fails silently for new contributors.

Added:

Instructions on how to generate a Deco deploy token

Steps for adding DECO_DEPLOY_TOKEN to GitHub Secrets

New section in README under “CI/CD Preview Deployments”

This improves onboarding and makes the preview workflow easier for first-time contributors.